### PR TITLE
fix(menu): 修复缩放滑块的值类型错误

### DIFF
--- a/menu.py
+++ b/menu.py
@@ -728,7 +728,7 @@ class SettingsMenu(FluentWindow):
         text_scale_factor.setText(str(float(conf.read_conf('General', 'scale')) * 100) + '%')  # 初始化缩放系数显示
 
         slider_scale_factor = self.adInterface.findChild(Slider, 'slider_scale_factor')
-        slider_scale_factor.setValue(float(conf.read_conf('General', 'scale')) * 100)
+        slider_scale_factor.setValue(int(float(conf.read_conf('General', 'scale')) * 100))
         slider_scale_factor.valueChanged.connect(
             lambda: (conf.write_conf('General', 'scale', str(slider_scale_factor.value() / 100)),
                      text_scale_factor.setText(str(slider_scale_factor.value()) + '%'))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "D:\Desktop\programming\Class-Widgets\exact_menu.py", line 35, in open_settings
    settings = SettingsMenu()
  File "D:\Desktop\programming\Class-Widgets\menu.py", line 367, in __init__
    self.init_window()
    ~~~~~~~~~~~~~~~~^^
  File "D:\Desktop\programming\Class-Widgets\menu.py", line 1869, in init_window
    self.load_all_item()
    ~~~~~~~~~~~~~~~~~~^^
  File "D:\Desktop\programming\Class-Widgets\menu.py", line 378, in load_all_item
    self.setup_advance_interface()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "D:\Desktop\programming\Class-Widgets\menu.py", line 731, in setup_advance_interface
    slider_scale_factor.setValue(float(conf.read_conf('General', 'scale')) * 100)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: setValue(self, a0: int): argument 1 has unexpected type 'float'
```

setValue的期望传入类型为int