### PR TITLE
fix(macos): 修复了一些窗口问题

### DIFF
--- a/exact_menu.py
+++ b/exact_menu.py
@@ -174,8 +174,6 @@ class ExactMenu(FluentWindow):
         self.move(int(screen_width / 2 - width / 2), 150)
         self.resize(width, height)
 
-        self.setWindowFlags(Qt.WindowType.Window)  # macOS 自动给焦点
-
         self.setWindowTitle('Class Widgets - 更多功能')
         self.setWindowIcon(QIcon(f'{base_directory}/img/logo/favicon-exmenu.ico'))
 

--- a/exact_menu.py
+++ b/exact_menu.py
@@ -174,8 +174,10 @@ class ExactMenu(FluentWindow):
         self.move(int(screen_width / 2 - width / 2), 150)
         self.resize(width, height)
 
+        self.setWindowFlags(Qt.WindowType.Window)  # macOS 自动给焦点
+
         self.setWindowTitle('Class Widgets - 更多功能')
-        self.setWindowIcon(QIcon('img/logo/favicon-exmenu.ico'))
+        self.setWindowIcon(QIcon(f'{base_directory}/img/logo/favicon-exmenu.ico'))
 
         self.addSubInterface(self.interface, fIcon.INFO, '更多设置')
 

--- a/main.py
+++ b/main.py
@@ -951,7 +951,8 @@ class FloatingWidget(QWidget):  # 浮窗
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
         self.setWindowFlags(
-            Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.Tool |
+            Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
+            Qt.WindowType.Widget | # macOS 失焦时仍然显示
             Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
         )
 
@@ -1239,17 +1240,18 @@ class DesktopWidget(QWidget):  # 主要小组件
 
         if conf.read_conf('General', 'pin_on_top') == '1':  # 置顶
             self.setWindowFlags(
-                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint | Qt.WindowType.Tool |
+                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
+                Qt.WindowType.Widget | # macOS 失焦时仍然显示
                 Qt.WindowType.WindowDoesNotAcceptFocus | Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
             )
         elif conf.read_conf('General', 'pin_on_top') == '2':  # 置底
             self.setWindowFlags(
-                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnBottomHint | Qt.WindowType.Tool |
+                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnBottomHint | Qt.WindowType.Widget |
                 Qt.WindowType.WindowDoesNotAcceptFocus
             )
         else:
             self.setWindowFlags(
-                Qt.WindowType.FramelessWindowHint | Qt.WindowType.Tool
+                Qt.WindowType.FramelessWindowHint | Qt.WindowType.Widget
             )
 
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)

--- a/main.py
+++ b/main.py
@@ -950,11 +950,17 @@ class FloatingWidget(QWidget):  # 浮窗
         # 设置窗口无边框和透明背景
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
-        self.setWindowFlags(
-            Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
-            Qt.WindowType.Widget | # macOS 失焦时仍然显示
-            Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
-        )
+        if sys.platform == 'darwin':
+            self.setWindowFlags(
+                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
+                Qt.WindowType.Widget | # macOS 失焦时仍然显示
+                Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
+            )
+        else:
+            self.setWindowFlags(Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
+                Qt.WindowType.Tool |
+                Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
+            )
 
         backgnd = self.findChild(QFrame, 'backgnd')
         shadow_effect = QGraphicsDropShadowEffect(self)
@@ -1241,18 +1247,23 @@ class DesktopWidget(QWidget):  # 主要小组件
         if conf.read_conf('General', 'pin_on_top') == '1':  # 置顶
             self.setWindowFlags(
                 Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnTopHint |
-                Qt.WindowType.Widget | # macOS 失焦时仍然显示
                 Qt.WindowType.WindowDoesNotAcceptFocus | Qt.X11BypassWindowManagerHint  # 绕过窗口管理器以在全屏显示通知
             )
+
         elif conf.read_conf('General', 'pin_on_top') == '2':  # 置底
             self.setWindowFlags(
-                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnBottomHint | Qt.WindowType.Widget |
+                Qt.WindowType.FramelessWindowHint | Qt.WindowType.WindowStaysOnBottomHint |
                 Qt.WindowType.WindowDoesNotAcceptFocus
             )
         else:
             self.setWindowFlags(
-                Qt.WindowType.FramelessWindowHint | Qt.WindowType.Widget
+                Qt.WindowType.FramelessWindowHint
             )
+
+        if sys.platform == 'darwin':
+            self.setWindowFlag(Qt.WindowType.Widget, True)
+        else:
+            self.setWindowFlag(Qt.WindowType.Tool, True)
 
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 

--- a/menu.py
+++ b/menu.py
@@ -1885,11 +1885,10 @@ class SettingsMenu(FluentWindow):
         self.resize(width, height)
 
         # macOS 标题栏显示 Windows 一样的按钮
-        self.titleBar.minBtn.setVisible(True)
-        self.titleBar.maxBtn.setVisible(True)
-        self.titleBar.closeBtn.setVisible(True)
-
-        self.setWindowFlags(Qt.WindowType.Window) # macOS 自动给焦点
+        if sys.platform == 'darwin':
+            self.titleBar.minBtn.setVisible(True)
+            self.titleBar.maxBtn.setVisible(True)
+            self.titleBar.closeBtn.setVisible(True)
 
         self.setWindowTitle('Class Widgets - 设置')
         self.setWindowIcon(QIcon(f'{base_directory}/img/logo/favicon-settings.ico'))

--- a/menu.py
+++ b/menu.py
@@ -1884,6 +1884,13 @@ class SettingsMenu(FluentWindow):
         self.move(int(screen_width / 2 - width / 2), 150)
         self.resize(width, height)
 
+        # macOS 标题栏显示 Windows 一样的按钮
+        self.titleBar.minBtn.setVisible(True)
+        self.titleBar.maxBtn.setVisible(True)
+        self.titleBar.closeBtn.setVisible(True)
+
+        self.setWindowFlags(Qt.WindowType.Window) # macOS 自动给焦点
+
         self.setWindowTitle('Class Widgets - 设置')
         self.setWindowIcon(QIcon(f'{base_directory}/img/logo/favicon-settings.ico'))
 

--- a/plugin_plaza.py
+++ b/plugin_plaza.py
@@ -705,6 +705,8 @@ class PluginPlaza(MSFluentWindow):
         self.move(int(screen_width / 2 - width / 2), 150)
         self.resize(width, height)
 
+        self.setWindowFlags(Qt.WindowType.Window)  # macOS 自动给焦点
+
         # 启动屏幕
         self.splashScreen = SplashScreen(self.windowIcon(), self)
         self.splashScreen.setIconSize(QSize(102, 102))

--- a/plugin_plaza.py
+++ b/plugin_plaza.py
@@ -705,8 +705,6 @@ class PluginPlaza(MSFluentWindow):
         self.move(int(screen_width / 2 - width / 2), 150)
         self.resize(width, height)
 
-        self.setWindowFlags(Qt.WindowType.Window)  # macOS 自动给焦点
-
         # 启动屏幕
         self.splashScreen = SplashScreen(self.windowIcon(), self)
         self.splashScreen.setIconSize(QSize(102, 102))


### PR DESCRIPTION
## 内容
- 修复了：
  - macOS: 失焦时不显示小组件和浮窗的问题
  - macOS: 设置标题栏没有按钮的问题
  - macOS: 设置、额外选项和插件广场在启动时不会自动焦点的问题
  - 全平台: #217 遗落的部分
 
## 测试
- [x] macOS 测试
- [ ] Windows 测试
- [ ] Linux 测试