### PR TITLE
fix: 将 pywin32 版本依赖从 306 改为 >= 306

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pyqt5-frameless-window==0.4.3
 pyqt5-qt5==5.15.2
 pyqt5-sip==12.15.0
 pyqt5-stubs==5.15.6.0
-pywin32==306
+pywin32>=306
 requests==2.32.3
 urllib3==2.2.3
 win32-setctime==1.1.0


### PR DESCRIPTION
```bash
D:\GitHub\Class-Widgets>pip install -r requirements.txt
Collecting git+https://github.com/CSES-org/pycses.git (from -r requirements.txt (line 22))
  Cloning https://github.com/CSES-org/pycses.git to c:\users\gytxt\appdata\local\temp\pip-req-build-ovvfnjnr
  Running command git clone --filter=blob:none --quiet https://github.com/CSES-org/pycses.git 'C:\Users\gytxt\AppData\Local\Temp\pip-req-build-ovvfnjnr'
  Resolved https://github.com/CSES-org/pycses.git to commit b51a94127d940a5f8633a9f511d074c92f9918b7
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting certifi==2024.8.30 (from -r requirements.txt (line 1))
  Downloading certifi-2024.8.30-py3-none-any.whl.metadata (2.2 kB)
Collecting charset-normalizer==3.3.2 (from -r requirements.txt (line 2))
  Downloading charset_normalizer-3.3.2-py3-none-any.whl.metadata (33 kB)
Requirement already satisfied: colorama==0.4.6 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 3)) (0.4.6)
Collecting configparser~=7.1.0 (from -r requirements.txt (line 4))
  Downloading configparser-7.1.0-py3-none-any.whl.metadata (5.4 kB)
Requirement already satisfied: darkdetect==0.8.0 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 5)) (0.8.0)
Requirement already satisfied: idna==3.10 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 6)) (3.10)
Requirement already satisfied: loguru~=0.7.2 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 7)) (0.7.3)
Requirement already satisfied: PyQt5~=5.15.11 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 8)) (5.15.11)
Requirement already satisfied: PyQt-Fluent-Widgets~=1.7.2 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 9)) (1.7.4)
Collecting pyqt5-frameless-window==0.4.3 (from -r requirements.txt (line 10))
  Downloading PyQt5_Frameless_Window-0.4.3-py3-none-any.whl.metadata (6.0 kB)
Requirement already satisfied: pyqt5-qt5==5.15.2 in e:\program files\python313\lib\site-packages (from -r requirements.txt (line 11)) (5.15.2)
Collecting pyqt5-sip==12.15.0 (from -r requirements.txt (line 12))
  Downloading PyQt5_sip-12.15.0.tar.gz (104 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Collecting pyqt5-stubs==5.15.6.0 (from -r requirements.txt (line 13))
  Downloading PyQt5_stubs-5.15.6.0-py3-none-any.whl.metadata (3.8 kB)
ERROR: Could not find a version that satisfies the requirement pywin32==306 (from versions: 307, 308)
ERROR: No matching distribution found for pywin32==306

D:\GitHub\Class-Widgets>pip install pywin32==308
Requirement already satisfied: pywin32==308 in e:\program files\python313\lib\site-packages (308)

D:\GitHub\Class-Widgets>pip install pywin32==306
ERROR: Could not find a version that satisfies the requirement pywin32==306 (from versions: 307, 308)
ERROR: No matching distribution found for pywin32==306
```

pip 中可能删除了 pywin32 的 306 版本，所以在安装此版本时报错

```bash
D:\GitHub\Class-Widgets>pip install pywin32==306
ERROR: Could not find a version that satisfies the requirement pywin32==306 (from versions: 307, 308)
ERROR: No matching distribution found for pywin32==306
```

由于 pip 中不再提供 pywin32==306 版本，更新了 requirements.txt 中的依赖版本范围，以确保能够正确安装。

因此提出此 PR。
