### PR TITLE
ci: 构建 macOS arm64 版本

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x86, x64 ]
-        os: [ ubuntu-20.04, windows-latest, macos-13 ]
+        arch: [ x86, x64, arm64 ]
+        os: [ ubuntu-20.04, windows-latest, macos-13, macos-14 ]
         exclude:
           - os: ubuntu-20.04
             arch: x86
+          - os: ubuntu-20.04
+            arch: arm64
           - os: macos-13
             arch: x86
+          - os: macos-13
+            arch: arm64
+          - os: windows-latest
+            arch: arm64
+          - os: macos-14
+            arch: x86
+          - os: macos-14
+            arch: x64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
             --hidden-import PyQt5.QtWebEngine
 
       - name: Run macOS build
-        if: ${{ matrix.os == 'macos-13' }}
+        if: ${{ startsWith(matrix.os, 'macos') }}
         run: |
           uv venv
           source .venv/bin/activate

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ loguru~=0.7.2
 PyQt5~=5.15.11
 PyQt-Fluent-Widgets~=1.7.2
 pyqt5-frameless-window==0.4.3
-pyqt5-qt5==5.15.2
+pyqt5-qt5~=5.15.2
 pyqt5-sip==12.15.0
 pyqt5-stubs==5.15.6.0
 pywin32==306; sys_platform == "win32"


### PR DESCRIPTION
把pyqt5-qt5的版本改为 `~=5.15.2`，这样可以在 Apple Silicon 的 Mac 上运行。