### PR TITLE
feat: 允许手动设置鼠标穿透

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -14,7 +14,8 @@
     "theme": "default",
     "scale": 1,
     "excluded_lesson": 0,
-    "excluded_lessons": ""
+    "excluded_lessons": "",
+    "enable_click": 1
   },
   "Toast": {
     "wave": 1,

--- a/main.py
+++ b/main.py
@@ -1324,7 +1324,7 @@ class DesktopWidget(QWidget):  # 主要小组件
         # 设置窗口无边框和透明背景
         self.setAttribute(Qt.WidgetAttribute.WA_TranslucentBackground)
 
-        if config_center.read_conf('General', 'hide') == '2':
+        if config_center.read_conf('General', 'hide') == '2' or (not int(config_center.read_conf('General', 'enable_click'))):
             self.setAttribute(Qt.WidgetAttribute.WA_TransparentForMouseEvents)
 
         if config_center.read_conf('General', 'pin_on_top') == '1':  # 置顶

--- a/menu.py
+++ b/menu.py
@@ -843,6 +843,11 @@ class SettingsMenu(FluentWindow):
         exclude_lesson.textChanged.connect(lambda: config_center.write_conf('General', 'excluded_lessons', exclude_lesson.text()))
         # 排除课程
 
+        switch_enable_click = self.adInterface.findChild(SwitchButton, 'switch_enable_click')
+        switch_enable_click.setChecked(int(config_center.read_conf('General', 'enable_click')))
+        switch_enable_click.checkedChanged.connect(lambda checked: switch_checked('General', 'enable_click', checked))
+        # 允许点击
+
         switch_enable_alt_schedule = self.adInterface.findChild(SwitchButton, 'switch_enable_alt_schedule')
         switch_enable_alt_schedule.setChecked(int(config_center.read_conf('General', 'enable_alt_schedule')))
         switch_enable_alt_schedule.checkedChanged.connect(

--- a/view/menu/advance.ui
+++ b/view/menu/advance.ui
@@ -858,6 +858,71 @@
              <number>16</number>
             </property>
             <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_18">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_22">
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="StrongBodyLabel" name="StrongBodyLabel_18">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="text">
+                   <string>允许点击或触摸小组件</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="CaptionLabel" name="CaptionLabel_15">
+                  <property name="text">
+                   <string>允许通过点击或触摸小组件方式控制小组件
+若启用，单击小组件可显示或隐藏小组件，右键小组件可打开额外选项
+若禁用，点击小组件等同于点击小组件后方的窗口
+* 重启后生效
+</string>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>false</bool>
+                  </property>
+                  <property name="lightColor" stdset="0">
+                   <color alpha="150">
+                    <red>0</red>
+                    <green>0</green>
+                    <blue>0</blue>
+                   </color>
+                  </property>
+                  <property name="darkColor" stdset="0">
+                   <color alpha="200">
+                    <red>255</red>
+                    <green>255</green>
+                    <blue>255</blue>
+                   </color>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+                <widget class="SwitchButton" name="switch_enable_click" native="true">
+                  <property name="onText" stdset="0">
+                  <string>启用</string>
+                  </property>
+                  <property name="offText" stdset="0">
+                  <string>禁用</string>
+                  </property>
+                </widget>
+                </item>
+             </layout>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout_14">
               <property name="spacing">
                <number>0</number>


### PR DESCRIPTION
允许通过点击或触摸小组件方式控制小组件
若启用，单击小组件可显示或隐藏小组件，右键小组件可打开额外选项
若禁用，点击小组件等同于点击小组件后方的窗口