### PR TITLE
fix(widgets): 主组件的移动速度异常

### DIFF
--- a/main.py
+++ b/main.py
@@ -1758,7 +1758,7 @@ class DesktopWidget(QWidget):  # 主要小组件
 
     def animate_show(self):  # 显示窗口
         self.animation = QPropertyAnimation(self, b"geometry")
-        self.animation.setDuration(400)  # 持续时间
+        self.animation.setDuration(525)  # 持续时间
         # 获取当前窗口的宽度和高度，确保动画过程中保持一致
         self.animation.setEndValue(
         QRect(self.x(), int(config_center.read_conf('General', 'margin')), self.width(), self.height()))

--- a/main.py
+++ b/main.py
@@ -995,7 +995,7 @@ class FloatingWidget(QWidget):  # 浮窗
         # 加载保存的位置
         saved_pos = self.load_position()
         if saved_pos:
-            # 添加边界检查
+            # 边界检查
             saved_pos = self.adjust_position_to_screen(saved_pos)
             self.position = saved_pos
         else:
@@ -1008,11 +1008,37 @@ class FloatingWidget(QWidget):  # 浮窗
         update_timer.add_callback(self.update_data)
 
     def adjust_position_to_screen(self, pos):
-        # 确保浮窗位置在屏幕可视范围内
-        screen_geometry = QApplication.primaryScreen().availableGeometry()
-        x = max(screen_geometry.left(), min(pos.x(), screen_geometry.right() - self.width()))
-        y = max(screen_geometry.top(), min(pos.y(), screen_geometry.bottom() - self.height()))
-        return QPoint(x, y)
+        screen = QApplication.screenAt(pos)
+        if not screen:
+            screen = QApplication.primaryScreen()
+        screen_geometry = screen.availableGeometry()
+        window_width = self.width()
+        window_height = self.height()
+        # 计算屏幕边界
+        screen_left = screen_geometry.x()
+        screen_right = screen_geometry.x() + screen_geometry.width()
+        screen_top = screen_geometry.y()
+        screen_bottom = screen_geometry.y() + screen_geometry.height()
+
+        new_x, new_y = pos.x(), pos.y()
+        if pos.x() < screen_left:
+        # 当窗口可见部分不足50%时调整
+            visible_width = (pos.x() + window_width) - screen_left
+            if visible_width < window_width / 2:
+                new_x = screen_left
+        elif (pos.x() + window_width) > screen_right:
+            visible_width = screen_right - pos.x()
+            if visible_width < window_width / 2:
+                new_x = screen_right - window_width
+        if pos.y() < screen_top:
+            visible_height = (pos.y() + window_height) - screen_top
+            if visible_height < window_height / 2:
+                new_y = screen_top
+        elif (pos.y() + window_height) > screen_bottom:
+            visible_height = screen_bottom - pos.y()
+            if visible_height < window_height / 2:
+                new_y = screen_bottom - window_height
+        return QPoint(new_x, new_y)
     
     def save_position(self):
         pos = self.pos()


### PR DESCRIPTION
**问题修复** 
1. **边界值处理**
   - 边距配置`max(0, value)`确保非负值
   - 修复窗口位置计算异常
2. **动画状态管理**
   - 执行动画时跳过数据更新逻辑（`if self.animating: return`）
   - 优化窗口显示动画时长至400ms
---
**功能优化** 
1. **动画优化**
   - 新增`sync_widget_animation`方法实现小部件与主组件动画同步
   - 主组件添加形变动画方法`animate_expand`
   - 加入弹出动画

2. **浮窗收起动画优化**
   - 浮窗收拢时同步执行渐隐动画
   - 动画目标位置改主组件坐标(上半部分);下部:主组件正下方屏幕外
   - 动画时长按照屏幕位置自动计算
---   
**演示**
*修复*

https://github.com/user-attachments/assets/93a31c0a-7128-46e5-ac00-28bba240795d

==>

https://github.com/user-attachments/assets/7135bbbd-c28d-4f32-b314-a3a97723ad22

*动画*


https://github.com/user-attachments/assets/258a15d4-b700-497e-8bf8-cd6e38dff0b2

