### PR TITLE
fix(tip_toast): 修正放学通知的条件判断逻辑

### DIFF
--- a/main.py
+++ b/main.py
@@ -1845,6 +1845,9 @@ def check_windows_maximize():  # 检查窗口是否最大化
     # 全字匹配以下关键词排除
     excluded_titles = {
         'ResidentSideBar', # 希沃侧边栏
+        'Program Manager', # Windows桌面
+        'Desktop', # Windows桌面
+        '', #空标题
         'SnippingTool', # 系统截图工具
     }
     # 包含以下关键词排除

--- a/tip_toast.py
+++ b/tip_toast.py
@@ -387,7 +387,7 @@ def main(state=1, lesson_name='', title='通知示例', subtitle='副标题',
 def detect_enable_toast(state=0):
     if config_center.read_conf('Toast', 'attend_class') != '1' and state == 1:
         return True
-    if config_center.read_conf('Toast', 'finish_class') != '1' and state == 0 or state == 2:
+    if (config_center.read_conf('Toast', 'finish_class') != '1') and (state in [0, 2]):
         return True
     if config_center.read_conf('Toast', 'prepare_class') != '1' and state == 3:
         return True


### PR DESCRIPTION
## 笑点解析
![image](https://github.com/user-attachments/assets/1d3c3dcf-a317-4964-be17-674bdc9d0285)(原代码)
 - state=2（放学）时，无论toast.finish_class配置如何都会返回True
 - 放学通知无法通过配置
---
clone #469 :通过显示测试(也不能说全是?)(休息段没法正常显示下课(我呃呃),,)