### PR TITLE
feat(FloatingWidget): 浮窗倒计时增强

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -10,6 +10,7 @@
     "hide_method": 0,
     "color_mode": 2,
     "enable_alt_schedule": 0,
+    "blur_floating_countdown": "1",
     "blur_countdown": 0,
     "theme": "default",
     "scale": 1,

--- a/main.py
+++ b/main.py
@@ -1079,6 +1079,7 @@ class FloatingWidget(QWidget):  # 浮窗
                     self.activity_countdown.setText(f"< {minutes} 分钟")
             else:  # 精确显示
                 self.activity_countdown.setText(cd_list[1])
+            self.countdown_progress_bar.setValue(cd_list[2])
 
         self.adjustSize_animation()
 

--- a/main.py
+++ b/main.py
@@ -1070,11 +1070,15 @@ class FloatingWidget(QWidget):  # 浮窗
         self.current_lesson_name_text.setText(current_lesson_name)
 
         if cd_list:  # 模糊倒计时
-            if cd_list[1] == '00:00':
-                self.activity_countdown.setText(f"< - 分钟")
-            else:
-                self.activity_countdown.setText(f"< {int(cd_list[1].split(':')[0]) + 1} 分钟")
-            self.countdown_progress_bar.setValue(cd_list[2])
+            blur_floating = config_center.read_conf('General', 'blur_floating_countdown') == '1'
+            if blur_floating:  # 模糊显示
+                if cd_list[1] == '00:00':
+                    self.activity_countdown.setText(f"< - 分钟")
+                else:
+                    minutes = int(cd_list[1].split(':')[0]) + 1
+                    self.activity_countdown.setText(f"< {minutes} 分钟")
+            else:  # 精确显示
+                self.activity_countdown.setText(cd_list[1])
 
         self.adjustSize_animation()
 

--- a/menu.py
+++ b/menu.py
@@ -718,6 +718,11 @@ class SettingsMenu(FluentWindow):
         blur_countdown.setChecked(int(config_center.read_conf('General', 'blur_countdown')))
         blur_countdown.checkedChanged.connect(lambda checked: switch_checked('General', 'blur_countdown', checked))
         # 模糊倒计时
+        switch_blur_floating = self.findChild(SwitchButton, 'switch_blur_countdown_2')
+        switch_blur_floating.setChecked(int(config_center.read_conf('General', 'blur_floating_countdown')))
+        switch_blur_floating.checkedChanged.connect(
+            lambda checked: config_center.write_conf('General', 'blur_floating_countdown', int(checked))
+        )
 
         select_weather_api = self.findChild(ComboBox, 'select_weather_api')  # 天气API选择
         select_weather_api.addItems(weather_db.api_config['weather_api_list_zhCN'])

--- a/view/menu/custom.ui
+++ b/view/menu/custom.ui
@@ -65,8 +65,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>640</width>
-        <height>1244</height>
+        <width>623</width>
+        <height>1224</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -588,7 +588,7 @@
          <item>
           <widget class="SubtitleLabel" name="SubtitleLabel_4">
            <property name="text">
-            <string>活动倒计时</string>
+            <string>倒计时模糊</string>
            </property>
            <property name="pixelFontSize" stdset="0">
             <number>18</number>
@@ -624,7 +624,7 @@
               <item>
                <widget class="StrongBodyLabel" name="StrongBodyLabel_2">
                 <property name="text">
-                 <string>模糊倒计时</string>
+                 <string>模糊主组件倒计时</string>
                 </property>
                </widget>
               </item>
@@ -652,7 +652,76 @@
              </layout>
             </item>
             <item>
-             <widget class="SwitchButton" name="switch_blur_countdown">
+             <widget class="SwitchButton" name="switch_blur_countdown" native="true">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="CardWidget" name="CardWidget_6">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>70</height>
+            </size>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_9">
+            <property name="leftMargin">
+             <number>16</number>
+            </property>
+            <property name="topMargin">
+             <number>16</number>
+            </property>
+            <property name="rightMargin">
+             <number>16</number>
+            </property>
+            <property name="bottomMargin">
+             <number>16</number>
+            </property>
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_12">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <item>
+               <widget class="StrongBodyLabel" name="StrongBodyLabel_6">
+                <property name="text">
+                 <string>模糊浮窗倒计时</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="CaptionLabel" name="CaptionLabel_8">
+                <property name="text">
+                 <string>将会以“&lt; x 分钟”的形式模糊地显示倒计时</string>
+                </property>
+                <property name="lightColor" stdset="0">
+                 <color alpha="150">
+                  <red>0</red>
+                  <green>0</green>
+                  <blue>0</blue>
+                 </color>
+                </property>
+                <property name="darkColor" stdset="0">
+                 <color alpha="200">
+                  <red>255</red>
+                  <green>255</green>
+                  <blue>255</blue>
+                 </color>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item>
+             <widget class="SwitchButton" name="switch_blur_countdown_2" native="true">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
                 <horstretch>0</horstretch>


### PR DESCRIPTION
### 摘要
---
#### 1. 新增精准浮窗倒计时功能
- **配置文件**
  - add `blur_floating_countdown` 配置项: 默认模糊启动
- **UI修改**
  - 在设置菜单新增「模糊浮窗倒计时」开关控件
---
#### 2. 浮窗时间颜色自定义功能
- **配置扩展**
  - 新增 `floating_time` 颜色配置项（默认 #959595(原色?)）
- **UI 优化**
  - 在颜色设置面板新增「浮窗时间颜色」配置卡