### PR TITLE
fix: 优化插件插件路径返回

### DIFF
--- a/main.py
+++ b/main.py
@@ -621,7 +621,7 @@ class PluginManager:  # 插件管理器
             "Weather_API": config_center.read_conf('Weather', 'api'),  # 天气API
             "Notification": notification.notification_contents,  # 检测到的通知内容
 
-            "PLUGIN_PATH": f'{conf.PLUGINS_DIR}/{path}',  # 传递插件目录
+            "PLUGIN_PATH": os.path.normpath(os.path.join(conf.PLUGINS_DIR, path)) if path else conf.PLUGINS_DIR,  # 传递插件目录
             "Config_Center": config_center,  # 配置中心实例
             "Schedule_Center": schedule_center,  # 课程表中心实例
             "Base_Directory": base_directory,  # 资源目录

--- a/plugin_plaza.py
+++ b/plugin_plaza.py
@@ -325,10 +325,10 @@ class PluginCard_Horizontal(CardWidget):  # 插件卡片（横向）
         self.installButton = PrimaryPushButton()
 
         # layout
-        self.hBoxLayout = QHBoxLayout(self)
+        self.hBoxLayout = QHBoxLayout()
         self.hBoxLayout_Title = QHBoxLayout()
         self.hBoxLayout_Author = QHBoxLayout()
-        self.vBoxLayout = QVBoxLayout(self)
+        self.vBoxLayout = QVBoxLayout()
 
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
         self.setFixedHeight(110)
@@ -376,6 +376,7 @@ class PluginCard_Horizontal(CardWidget):  # 插件卡片（横向）
 
         self.hBoxLayout.addLayout(self.vBoxLayout)
         self.hBoxLayout.addWidget(self.installButton)
+        self.setLayout(self.hBoxLayout)
 
         self.hBoxLayout_Title.setSpacing(12)
         self.hBoxLayout_Title.addWidget(self.titleLabel, 0, Qt.AlignmentFlag.AlignVCenter)
@@ -650,8 +651,9 @@ class PluginPlaza(MSFluentWindow):
                     banner_placeholders = ["img/plaza/banner_pre.png" for _ in range(len(data))]
                     self.banner_view.addImages(banner_placeholders)
                 else:
-                    logger.error(f'PluginPlaza 无法联网，错误：{data["error"]}')
-                    self.findChild(BodyLabel, 'tips').setText(f'错误原因：{data["error"]}')
+                    error_info = data.get("error", "未知错误")
+                    logger.error(f'PluginPlaza 无法联网,错误：{error_info}')
+                    self.findChild(BodyLabel, 'tips').setText(f'错误原因：{error_info}')
                     self.banner_view.addImage("img/plaza/banner_network-failed.png")
                     self.splashScreen.hide()
                     self.homeInterface.findChild(SubtitleLabel, 'SubtitleLabel_3').hide()  # 隐藏副标题

--- a/plugin_plaza.py
+++ b/plugin_plaza.py
@@ -655,6 +655,7 @@ class PluginPlaza(MSFluentWindow):
                     logger.error(f'PluginPlaza 无法联网,错误：{error_info}')
                     self.findChild(BodyLabel, 'tips').setText(f'错误原因：{error_info}')
                     self.banner_view.addImage("img/plaza/banner_network-failed.png")
+                    self.banner_view.addImage("img/plaza/banner_network-failed.png")
                     self.splashScreen.hide()
                     self.homeInterface.findChild(SubtitleLabel, 'SubtitleLabel_3').hide()  # 隐藏副标题
                     return


### PR DESCRIPTION
# 总览
- 插件路径处理优化
- 布局分配逻辑

### 1. 优化插件路径处理
#### `main.py`
   - 直接用 `os.path.normpath` 和 `os.path.join` 拼接路径,防止出现非正常的解析路径

### 2. 优化布局分配逻辑
#### `plugin_plaza.py`
   - `QHBoxLayout` 和 `QVBoxLayout` 改为独立创建，避免重复分配
