### PR TITLE
revert: qfw 中 deregister 错误绑定造成的更改主题访问已删除元素

### DIFF
--- a/extra_menu.py
+++ b/extra_menu.py
@@ -212,10 +212,6 @@ class ExtraMenu(FluentWindow):
 
         self.addSubInterface(self.interface, fIcon.INFO, '更多设置')
 
-    def closeEvent(self, e):
-        self.deleteLater()
-        return super().closeEvent(e)
-
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)

--- a/extra_menu.py
+++ b/extra_menu.py
@@ -212,6 +212,10 @@ class ExtraMenu(FluentWindow):
 
         self.addSubInterface(self.interface, fIcon.INFO, '更多设置')
 
+    def closeEvent(self, e):
+        self.deleteLater()
+        return super().closeEvent(e)
+
 
 if __name__ == '__main__':
     app = QApplication(sys.argv)

--- a/main.py
+++ b/main.py
@@ -25,46 +25,6 @@ from qfluentwidgets import Theme, setTheme, setThemeColor, SystemTrayMenu, Actio
     Dialog, ProgressRing, PlainTextEdit, ImageLabel, PushButton, InfoBarIcon, Flyout, FlyoutAnimationType, CheckBox, \
     PrimaryPushButton, IconWidget
 
-# patch: 由于 deregister 错误绑定造成的更改主题访问已删除元素
-import qfluentwidgets.common.style_sheet as qss
-
-class StyleSheetManager(qss.StyleSheetManager):
-
-    def register(self, source, widget: QWidget, reset=True):
-        from qfluentwidgets import StyleSheetFile, StyleSheetCompose, CustomStyleSheet
-        from qfluentwidgets.common.style_sheet import CustomStyleSheetWatcher, DirtyStyleSheetWatcher
-        """ register widget to manager
-
-        Parameters
-        ----------
-        source: str | StyleSheetBase
-            qss source, it could be:
-            * `str`: qss file path
-            * `StyleSheetBase`: style sheet instance
-
-        widget: QWidget
-            the widget to set style sheet
-
-        reset: bool
-            whether to reset the qss source
-        """
-        if isinstance(source, str):
-            source = StyleSheetFile(source)
-
-        if widget not in self.widgets:
-            widget.destroyed.connect(lambda: self.deregister(widget))
-            widget.installEventFilter(CustomStyleSheetWatcher(widget))
-            widget.installEventFilter(DirtyStyleSheetWatcher(widget))
-            self.widgets[widget] = StyleSheetCompose([source, CustomStyleSheet(widget)])
-
-        if not reset:
-            self.source(widget).add(source)
-        else:
-            self.widgets[widget] = StyleSheetCompose([source, CustomStyleSheet(widget)])
-
-qss.styleSheetManager = StyleSheetManager()
-# end of patch
-
 import conf
 import list_
 import tip_toast


### PR DESCRIPTION
Reverts Class-Widgets/Class-Widgets#569

上游将修复。

This reverts commit https://github.com/Class-Widgets/Class-Widgets/commit/c440a9000dd4288afc372bddf81d5a12b2aa4112