### PR TITLE
doc: README 中社区开发者名单非团队人员无法访问

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 > [!Warning]
 > Class Widgets *1* 目前完全由社区开发者进行开发
-> ![](https://cwclist.hpdnya.com/)
+> 
+> [![](https://avatars.githubusercontent.com/u/71167373?v=4&s=80)](https://github.com/pizeroLOL) [![](https://avatars.githubusercontent.com/u/120182813?v=4&s=80)](https://github.com/IsHPDuwu) [![](https://avatars.githubusercontent.com/u/121741105?v=4&s=80)](https://github.com/baiyao105) [![](https://avatars.githubusercontent.com/u/192969678?v=4&s=80)](https://github.com/Artist-MOBAI)
+
+> 
 > 有任何需要社区开发者帮忙的地方，请前往 QQ 群或提 issue
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 > [!Warning]
-> Class Widgets *1* 目前完全由社区开发者进行开发，详见[此处](https://github.com/Class-Widgets/Class-Widgets/graphs/contributors)
+> Class Widgets *1* 目前完全由社区开发者进行开发
+> ![](https://cwclist.hpdnya.com/)
+> 有任何需要社区开发者帮忙的地方，请前往 QQ 群或提 issue
 
 > [!NOTE]
 > Class Widgets 有 QQ 群和 Discord 服务器啦！详见[此处](#社区)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 > [!Warning]
 > Class Widgets *1* 目前完全由社区开发者进行开发
 > 
-> [![](https://avatars.githubusercontent.com/u/71167373?v=4&s=80)](https://github.com/pizeroLOL) [![](https://avatars.githubusercontent.com/u/120182813?v=4&s=80)](https://github.com/IsHPDuwu) [![](https://avatars.githubusercontent.com/u/121741105?v=4&s=80)](https://github.com/baiyao105) [![](https://avatars.githubusercontent.com/u/192969678?v=4&s=80)](https://github.com/Artist-MOBAI)
-
+> [![](https://github.com/pizeroLOL.png?size=80)](https://github.com/pizeroLOL) [![](https://github.com/IsHPDuwu.png?size=80)](https://github.com/IsHPDuwu) [![](https://github.com/baiyao105.png?size=80)](https://github.com/baiyao105) [![](https://github.com/Artist-MOBAI.png?size=80)](https://github.com/Artist-MOBAI)
 > 
 > 有任何需要社区开发者帮忙的地方，请前往 QQ 群或提 issue
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 > [!Warning]
 > Class Widgets *1* 目前完全由社区开发者进行开发
 > 
-> <a href="https://github.com/pizeroLOL"><img src="https://avatars.githubusercontent.com/u/71167373?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/IsHPDuwu"><img src="https://avatars.githubusercontent.com/u/120182813?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/baiyao105"><img src="https://avatars.githubusercontent.com/u/121741105?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/Artist-MOBAI"><img src="https://avatars.githubusercontent.com/u/192969678?v=4&s=80" width="80" style="border-radius:50%;" /></a>
-
+> [![](https://avatars.githubusercontent.com/u/71167373?v=4&s=80)](https://github.com/pizeroLOL) [![](https://avatars.githubusercontent.com/u/120182813?v=4&s=80)](https://github.com/IsHPDuwu) [![](https://avatars.githubusercontent.com/u/121741105?v=4&s=80)](https://github.com/baiyao105) [![](https://avatars.githubusercontent.com/u/192969678?v=4&s=80)](https://github.com/Artist-MOBAI)
 
 > 
 > 有任何需要社区开发者帮忙的地方，请前往 QQ 群或提 issue

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 > [!Warning]
-> Class Widgets *1* 目前完全由社区开发者进行开发，详见[此处](https://github.com/orgs/Class-Widgets/teams/community/members)
+> Class Widgets *1* 目前完全由社区开发者进行开发，详见[此处](https://github.com/Class-Widgets/Class-Widgets/graphs/contributors)
 
 > [!NOTE]
 > Class Widgets 有 QQ 群和 Discord 服务器啦！详见[此处](#社区)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 > [!Warning]
 > Class Widgets *1* 目前完全由社区开发者进行开发
 > 
-> [![](https://avatars.githubusercontent.com/u/71167373?v=4&s=80)](https://github.com/pizeroLOL) [![](https://avatars.githubusercontent.com/u/120182813?v=4&s=80)](https://github.com/IsHPDuwu) [![](https://avatars.githubusercontent.com/u/121741105?v=4&s=80)](https://github.com/baiyao105) [![](https://avatars.githubusercontent.com/u/192969678?v=4&s=80)](https://github.com/Artist-MOBAI)
+> <a href="https://github.com/pizeroLOL"><img src="https://avatars.githubusercontent.com/u/71167373?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/IsHPDuwu"><img src="https://avatars.githubusercontent.com/u/120182813?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/baiyao105"><img src="https://avatars.githubusercontent.com/u/121741105?v=4&s=80" width="80" style="border-radius:50%;" /></a><a href="https://github.com/Artist-MOBAI"><img src="https://avatars.githubusercontent.com/u/192969678?v=4&s=80" width="80" style="border-radius:50%;" /></a>
+
 
 > 
 > 有任何需要社区开发者帮忙的地方，请前往 QQ 群或提 issue


### PR DESCRIPTION
原链接情况如下:
![image](https://github.com/user-attachments/assets/ca782e83-7934-464e-b81b-1c98a673876a)
经更改后符合要求