### PR TITLE
revert: "chore(deps): bump urllib3 from 2.2.3 to 2.5.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ pyqt5-stubs==5.15.6.0
 pywin32==306; platform_system == "Windows"
 psutil==5.9.5
 requests==2.32.4
-urllib3==2.5.0
+urllib3==2.2.3
 win32-setctime==1.1.0
 PyQtWebEngine~=5.15.7
 Markdown~=3.7


### PR DESCRIPTION
This reverts commit af72c69ee0f9a0dd6c6170a03152c6ee3cebe07f.

```
ERROR: Could not find a version that satisfies the requirement urllib3==2.5.0 (from versions: 0.3, 1.0, 1.0.1, 1.0.2, 1.1, 1.2, 1.2.1, 1.2.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.7.1, 1.8, 1.8.2, 1.8.3, 1.9, 1.9.1, 1.10, 1.10.1, 1.10.2, 1.10.3, 1.10.4, 1.11, 1.12, 1.13, 1.13.1, 1.14, 1.15, 1.15.1, 1.16, 1.17, 1.18, 1.18.1, 1.19, 1.19.1, 1.20, 1.21, 1.21.1, 1.22, 1.23, 1.24, 1.24.1, 1.24.2, 1.24.3, 1.25.2, 1.25.3, 1.25.4, 1.25.5, 1.25.6, 1.25.7, 1.25.8, 1.25.9, 1.25.10, 1.25.11, 1.26.0, 1.26.1, 1.26.2, 1.26.3, 1.26.4, 1.26.5, 1.26.6, 1.26.7, 1.26.8, 1.26.9, 1.26.10, 1.26.11, 1.26.12, 1.26.13, 1.26.14, 1.26.15, 1.26.16, 1.26.17, 1.26.18, 1.26.19, 1.26.20, 2.0.0a1, 2.0.0a2, 2.0.0a3, 2.0.0a4, 2.0.2, 2.0.3, 2.0.4, 2.0.5, 2.0.6, 2.0.7, 2.1.0, 2.2.0, 2.2.1, 2.2.2, 2.2.3)
ERROR: No matching distribution found for urllib3==2.5.0
```