### PR TITLE
chore: "Potential fix for code scanning alert no. 52: Wrong number of arguments in a call"

### DIFF
--- a/main.py
+++ b/main.py
@@ -1695,7 +1695,7 @@ class DesktopWidget(QWidget):  # 主要小组件
         self.weather_alert_text = None
         self.alert_showing = False
 
-        self.position = parent.get_widget_pos(self.path) if position is None else position
+        self.position = parent.get_widget_pos(self.path, None) if position is None else position
         self.animation = None
         self.opacity_animation = None
         mgr.hide_status = None


### PR DESCRIPTION
Potential fix for [https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/52](https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/52)

To fix the issue, the call to `get_widget_pos` on line 1698 should be updated to include the `cnt` argument. Since the `cnt` parameter is optional and defaults to `None`, the fix can either explicitly pass `None` or provide a meaningful value based on the context of the code. If the `cnt` value is not readily available, passing `None` ensures the method behaves as intended without introducing ambiguity.

The fix involves:
1. Updating the call to `parent.get_widget_pos(self.path)` to include the `cnt` argument.
2. Ensuring that the value passed for `cnt` aligns with the intended logic of the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
