### PR TITLE
chore: Illegal raise (fixed)

### DIFF
--- a/weather.py
+++ b/weather.py
@@ -56,7 +56,7 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0):
                     else:
                         logger.error(f"{func.__name__} 所有重试均失败: {e}")
             if last_exception is None:
-                raise RuntimeError(f"{func.__name__} failed after {max_retries} retries, but no exception was captured.")
+                raise RuntimeError(f"{func.__name__} 在 {max_retries} 次重试后出现未知问题")
             raise last_exception
         return wrapper
     return decorator

--- a/weather.py
+++ b/weather.py
@@ -55,6 +55,8 @@ def retry_on_failure(max_retries: int = 3, delay: float = 1.0):
                         time.sleep(delay)
                     else:
                         logger.error(f"{func.__name__} 所有重试均失败: {e}")
+            if last_exception is None:
+                raise RuntimeError(f"{func.__name__} failed after {max_retries} retries, but no exception was captured.")
             raise last_exception
         return wrapper
     return decorator


### PR DESCRIPTION
Potential fix for [https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/13](https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/13)

To fix the issue, we need to ensure that a valid exception is always raised on line 58. If `last_exception` is `None`, it means no exception was caught during the retries, which is unexpected. In such cases, we can raise a generic exception with a descriptive error message. This ensures that the `raise` statement always raises a valid exception object.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
