### PR TITLE
Potential fix for code scanning alert no. 116: Unhashable object hashed

### DIFF
--- a/main.py
+++ b/main.py
@@ -528,7 +528,7 @@ def get_hide_status() -> int:
         '1': lambda: current_state,
         '2': lambda: check_windows_maximize() or check_fullscreen(),
         '3': lambda: current_state
-    }[config_center.read_conf('General', 'hide')]() and not (current_lesson_name in excluded_lessons) else 0
+    }[str(config_center.read_conf('General', 'hide'))]() and not (current_lesson_name in excluded_lessons) else 0
 
 
 # 定义 RECT 结构体


### PR DESCRIPTION
Potential fix for [https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/116](https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/116)

To fix the issue, we need to ensure that the value returned by `config_center.read_conf('General', 'hide')` is hashable before it is used as a key in the dictionary. A common approach is to explicitly cast the value to a string, as strings are hashable and would work with the existing dictionary keys. This can be done using the `str()` function. If the value is already a string, this cast will have no effect; if it is not, it will be converted to a string representation.

The fix involves modifying line 531 to cast the result of `config_center.read_conf('General', 'hide')` to a string before using it as a key.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
