### PR TITLE
fix: default_config.json 中数据类型不为 str 导致的读取类型不定

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -1,40 +1,40 @@
 {
   "General": {
     "schedule": "新课表 - 1.json",
-    "pin_on_top": 1,
-    "margin": 10,
-    "opacity": 95,
-    "auto_startup": 0,
-    "hide": 0,
-    "hide_method": 0,
-    "color_mode": 2,
-    "enable_alt_schedule": 0,
+    "pin_on_top": "1",
+    "margin": "10",
+    "opacity": "95",
+    "auto_startup": "0",
+    "hide": "0",
+    "hide_method": "0",
+    "color_mode": "2",
+    "enable_alt_schedule": "0",
     "blur_floating_countdown": "1",
-    "blur_countdown": 0,
+    "blur_countdown": "0",
     "theme": "default",
-    "scale": 1,
-    "excluded_lesson": 0,
+    "scale": "1",
+    "excluded_lesson": "0",
     "excluded_lessons": "",
-    "enable_click": 1,
-    "enable_display_full_next_lessons": 1,
+    "enable_click": "1",
+    "enable_display_full_next_lessons": "1",
     "language_view": "system"
   },
   "Toast": {
-    "wave": 1,
-    "pin_on_top": 1,
-    "ringtone": 1,
-    "prepare_minutes": 2,
-    "attend_class": 1,
-    "finish_class": 1,
-    "prepare_class": 1,
-    "after_school": 1
+    "wave": "1",
+    "pin_on_top": "1",
+    "ringtone": "1",
+    "prepare_minutes": "2",
+    "attend_class": "1",
+    "finish_class": "1",
+    "prepare_class": "1",
+    "after_school": "1"
   },
   "TTS": {
-    "enable": 0,
+    "enable": "0",
     "engine": "edge",
     "language": "zh-CN",
     "voice_id": "",
-    "speed": 50,
+    "speed": "50",
     "attend_class": "活动开始, {lesson_name}",
     "finish_class": "活动结束, 下一节课 {lesson_name}",
     "prepare_class": "活动即将开始, 下一节课 {lesson_name}",
@@ -42,7 +42,7 @@
     "otherwise": ""
   },
   "Weather": {
-    "city": 0,
+    "city": "0",
     "api": "xiaomi_weather",
     "api_key": ""
   },
@@ -53,19 +53,19 @@
     "prepare_class": "7065D8"
   },
   "Plugin": {
-    "version": 2,
+    "version": "2",
     "mirror": "gh_proxy",
-    "auto_delay": 5,
-    "auto_enable_plugin": 1
+    "auto_delay": "5",
+    "auto_enable_plugin": "1"
   },
   "Time": {
-    "time_offset": 0,
+    "time_offset": "0",
     "type": "ntp",
     "ntp_server": "ntp.aliyun.com",
     "timezone": "local",
-    "enable_ntp_auto_refresh": 1,
-    "ntp_auto_refresh": 10,
-    "switch_enable_ntp_auto_sync": 1
+    "enable_ntp_auto_refresh": "1",
+    "ntp_auto_refresh": "10",
+    "switch_enable_ntp_auto_sync": "1"
   },
   "Date": {
     "start_date": "",
@@ -75,7 +75,7 @@
     "countdown_custom_mode": 1
   },
   "Audio": {
-    "volume": 75,
+    "volume": "75",
     "attend_class": "attend_class.wav",
     "finish_class": "finish_class.wav",
     "prepare_class": "prepare_class.wav"
@@ -87,9 +87,9 @@
   },
   "Version": {
     "version": "v1.1.7.2",
-    "version_channel": 0,
-    "auto_check_update": 1,
-    "cses_version": 1,
+    "version_channel": "0",
+    "auto_check_update": "1",
+    "cses_version": "1",
     "build_time": "__BUILD_TIME__",
     "build_commit": "__BUILD_COMMIT__",
     "build_branch": "__BUILD_BRANCH__",
@@ -97,10 +97,10 @@
     "build_type": "__BUILD_TYPE__"
   },
   "Other": {
-    "do_not_log": 0,
-    "safe_mode": 0,
-    "safe_plugin": 1,
-    "initialstartup": 1,
-    "multiple_programs": 0
+    "do_not_log": "0",
+    "safe_mode": "0",
+    "safe_plugin": "1",
+    "initialstartup": "1",
+    "multiple_programs": "0"
   }
 }


### PR DESCRIPTION
当前 config_center.read_conf 在调用时已经默认其读取出是 str，但当 config.ini 没有相关数据时会直接从 default_config.json 中读取，而 default_config.json 中的部分整数、小数类型可能导致程序数据异常，故将 default_config.json 中所有字段改为 str