### PR TITLE
Potential fix for code scanning alert no. 134: Use of the return value of a procedure

### DIFF
--- a/generate_speech.py
+++ b/generate_speech.py
@@ -986,10 +986,10 @@ def stop_tts() -> bool:
     global _tts_playing
     try:
         from play_audio import stop_audio
-        success = stop_audio()
+        stop_audio()
         with _tts_lock:
             _tts_playing = False
-        return success
+        return True
     except Exception as e:
         logger.warning(f"停止TTS播放失败: {e}")
         with _tts_lock:


### PR DESCRIPTION
Potential fix for [https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/134](https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/134)

To fix the issue, we will remove the assignment of the return value of `stop_audio()` to the variable `success`. Instead, we will call `stop_audio()` directly without assigning its return value. Additionally, we will remove any subsequent use of the `success` variable, as it is unnecessary and misleading.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
