### PR TITLE
Potential fix for code scanning alert no. 284: Duplication in regular expression character class

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ package = ["pyinstaller>=6.15.0"]
 
 [project]
 dependencies = [
-  "annotated-types==0.7.0",
+  "regex==2025.7.34","annotated-types==0.7.0",
   "certifi==2025.8.3",
   "charset-normalizer==3.4.2",
   "colorama==0.4.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ package = ["pyinstaller>=6.15.0"]
 
 [project]
 dependencies = [
-  "regex==2025.7.34","annotated-types==0.7.0",
+  "annotated-types==0.7.0",
   "certifi==2025.8.3",
   "charset-normalizer==3.4.2",
   "colorama==0.4.6",
@@ -42,6 +42,7 @@ dependencies = [
   "pyttsx3~=2.99",
   "pytz~=2025.2",
   "pywin32==311 ; sys_platform == 'win32'",
+  "regex==2025.7.34",
   "requests==2.32.4",
   "typing-extensions==4.13.2",
   "urllib3==2.2.3",

--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ import datetime as dt
 import inspect
 import os
 import re
+import regex
 import signal
 import sys
 import threading
@@ -430,8 +431,8 @@ class UnionUpdateTimer(QObject):
 
 
 # 匹配中文字符(预编译)
-_CHINESE_CHAR_PATTERN = re.compile(
-    r"[\u4e00-\u9fff\u3400-\u4dbf\u20000-\u2a6df\u2a700-\u2b73f\u2b740-\u2b81f\u2b820-\u2ceaf\u2ceb0-\u2ebef]"
+_CHINESE_CHAR_PATTERN = regex.compile(
+    r"[\u4e00-\u9fff\u3400-\u4dbf\U00020000-\U0002A6DF\U0002A700-\U0002B73F\U0002B740-\U0002B81F\U0002B820-\U0002CEAF\U0002CEB0-\U0002EBEF]"
 )
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/284](https://github.com/Class-Widgets/Class-Widgets/security/code-scanning/284)

The problem is that the regular expression at line 434 is written with square brackets, causing everything inside to be treated as individual characters, not code points or ranges. This includes duplicate characters (including '0'), and does *not* properly match Unicode characters outside the BMP (i.e., code points above U+FFFF, e.g., U+20000). The correct way to specify ranges of Chinese characters is to use `[ ]` with valid ranges, but Python's `re` module supports only four-digit `\u` escapes in character classes, so only the BMP range works as intended. If support for supplementary plane Unicode ranges is needed, you must use the third-party `regex` module (installable via `pip install regex`), which allows `\UXXXXXXXX` in character classes.

To fix this:
- Remove duplicate characters/ranges.
- For accurate matching of all described Chinese Unicode ranges, switch from `re` to `regex`, and write the pattern using valid code point range escapes, i.e., `r'[\u4e00-\u9fff\u3400-\u4dbf\U00020000-\U0002A6DF\U0002A700-\U0002B73F\U0002B740-\U0002B81F\U0002B820-\U0002CEAF\U0002CEB0-\U0002EBEF]'`.
- Import the `regex` module if not yet present, and adjust the `_CHINESE_CHAR_PATTERN` assignment to use it instead of `re`.

The only changes required are:
- Add the import for `regex` (if not yet present).
- Update line 433–435 to use `regex.compile` with the fixed pattern using valid Unicode escape syntax.

If you cannot use the `regex` module (i.e., must stick with built-in `re`), then restrict to BMP and remove the faulty ranges, but this will not match all the intended Chinese ranges.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
