### PR TITLE
improve(basic_dirs): 在 Linux 安装版中自动使用 XDG 目录

### DIFF
--- a/basic_dirs.py
+++ b/basic_dirs.py
@@ -25,7 +25,9 @@ def _get_app_dir(
 ) -> Path:
     """获取应用目录的通用实现"""
     if IS_PORTABLE:
-        return _ensure_dir(CW_HOME / default_subdir)
+        # 处理 Linux 安装版路径
+        if not CW_HOME.as_posix().startswith("/opt/apps"):
+            return _ensure_dir(CW_HOME / default_subdir)
 
     # 处理自定义路径
     if custom := os.environ.get(f"CLASSWIDGETS_CUSTOM_{purpose.upper()}_HOME"):


### PR DESCRIPTION
优化了 basic_dirs 的获取。当软件在 Linux 的安装目录 `/opt/apps` 中，即使没有 `CLASSWIDGETS_NOT_PORTABLE` 环境变量，也会使用 XDG 用户目录。